### PR TITLE
Prevent version match failure in non-windows OS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { getIsWindows, getWindowsVersion } = require('./utils')
 const { noop, NoopClass } = require('./noops')
-const win = getWindowsVersion()
+const win = getIsWindows() ? getWindowsVersion() : null
 
 /**
  * Overrides the logger on all methods and classes.
@@ -15,7 +15,7 @@ let exp
 
 // Requiring native Windows stuff on a non-windows machine isn't a great idea,
 // so we just export no-ops with console warnings.
-if (!getIsWindows() || !(win === '10.0' || win === '8.1' || win === '8')) {
+if (!(win === '10.0' || win === '8.1' || win === '8')) {
   exp = {
     Notification: NoopClass,
     history: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,10 @@ const utils = {
   getWindowsVersion (version = os.release()) {
     let match = version.match(/^(\d+).?(\d+).?(\*|\d+)$/)
 
+    if (match === null) {
+      return version
+    }
+
     // We got major, minor
     if (match.length > 2 && match[1] === '6' && match[2] === '1') {
       return '7.0'

--- a/test/src/utils.js
+++ b/test/src/utils.js
@@ -22,6 +22,12 @@ describe('Utils', () => {
     version.should.be.equal('7.0')
   })
 
+  it('getWindowsVersion returns version as is for non-matching version', () => {
+    const nonMatch = '4.7.4-ph+'
+    let version = getWindowsVersion(nonMatch)
+    version.should.be.equal(nonMatch)
+  })
+
   it('getIsWindows returns true for Windows', () => {
     let platform = getIsWindows('win32')
     platform.should.be.equal(true)
@@ -29,6 +35,11 @@ describe('Utils', () => {
 
   it('getIsWindows returns false for macOS', () => {
     let platform = getIsWindows('darwin')
+    platform.should.be.equal(false)
+  })
+
+  it('getIsWindows returns false for linux', () => {
+    let platform = getIsWindows('linux')
     platform.should.be.equal(false)
   })
 })


### PR DESCRIPTION
This PR updates behaviors of `getWindowVersion` to return original version string if given version does not matches, also updates module init logic to invoke matching only if given OS is windows - checking platform up front to avoid unnecessary version match failure.