### PR TITLE
Mark this package as Windows-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "nodert",
     "winrt"
   ],
+  "os": ["win32"],
   "author": "",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This means that it won't be installed in cross-platform projects that mark it as an `optionalDependency`