### PR TITLE
Replace debug-electron with debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "standard": "^8.1.0"
   },
   "dependencies": {
-    "debug-electron": "0.0.1",
+    "debug": "^2.5.1",
     "is-electron-renderer": "^2.0.1",
     "uuid": "^3.0.0",
     "xml-escape": "^1.1.0"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const os = require('os')
 
-let d = require('debug-electron')('electron-windows-notifications:tile-notification')
+let d = require('debug')('electron-windows-notifications:tile-notification')
 
 const utils = {
   /**


### PR DESCRIPTION
debug-electron is no longer needed (and in fact, old versions are busted), the original issue is patched in debug itself